### PR TITLE
[bugfix] fix experimental warnings

### DIFF
--- a/conf/log4perl.conf
+++ b/conf/log4perl.conf
@@ -7,3 +7,8 @@ log4perl.appender.LOGFILE.mode=append
 log4perl.appender.LOGFILE.stderr=0
 log4perl.appender.LOGFILE.layout=PatternLayout
 log4perl.appender.LOGFILE.layout.ConversionPattern = [%d][%-5p] %m{chomp}%n
+
+log4perl.appender.SCREEN = Log::Log4perl::Appender::Screen
+log4perl.appender.SCREEN.stderr=0
+log4perl.appender.SCREEN.layout=PatternLayout
+log4perl.appender.SCREEN.layout.ConversionPattern = [%d][%-5p] %m{chomp}%n

--- a/conf/primary.query.props.pl
+++ b/conf/primary.query.props.pl
@@ -1,5 +1,5 @@
 {
-  query_list     => ['archivelog_seq'],
+  list           => ['archivelog_seq'],
   archivelog_seq => {
     query => q{
         select max (sequence#) from v$log_history

--- a/conf/query.props.pl
+++ b/conf/query.props.pl
@@ -1,5 +1,5 @@
 {
-  query_list => [
+  list => [
     'archivelog_switch',      'uptime',
     'dbblockgets',            'dbconsistentgets',
     'dbphysicalreads',        'dbblockchanges',

--- a/conf/standby.query.props.pl
+++ b/conf/standby.query.props.pl
@@ -1,5 +1,5 @@
 {
-  query_list         => ['archivelog_applied'],
+  list               => ['archivelog_applied'],
   archivelog_applied => {
     query => q{
         select max (sequence#)

--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires "IO::Socket::INET" => "0";
 requires "JSON" => "0";
 requires "Log::Any::Adapter::Log4perl" => "0";
 requires "Log::Log4perl" => "0";
+requires "Moo" => "0";
 requires "perl" => "5.010";
 requires "strict" => "0";
 requires "Time::HiRes" => "0";

--- a/lib/ZDBA/Utils.pm
+++ b/lib/ZDBA/Utils.pm
@@ -16,7 +16,7 @@ sub hash_merge {
   return unless $source;
   return unless ref $target eq 'HASH' && ref $target eq ref $source;
 
-  no warnings 'experimental';
+  no if ($PERL_VERSION >= 5.018), warnings => 'experimental';
   for my $key ( keys %{$source} ) {
     if ( exists $target->{$key} ) {
       next unless ref $target->{$key} eq ref $source->{$key};
@@ -30,7 +30,7 @@ sub hash_merge {
       $target->{$key} = $source->{$key}
     }
   }
-  use warnings 'experimental';
+  use if ($PERL_VERSION >= 5.018), warnings => 'experimental';
 
   return $target;
 }

--- a/zdba.pl
+++ b/zdba.pl
@@ -10,6 +10,7 @@ use File::Spec;
 use Log::Log4perl ':easy';
 use Log::Any::Adapter;
 
+use lib File::Spec->catpath( $Bin, 'lib' );
 use ZDBA;
 
 my $running = 1;


### PR DESCRIPTION
fix experimental warnings on older perl versions (< 5.018)

additional fixes:
- add abitily to log to screen (eg. for docker)
- rename `query_list` -> `list` in query files
- add Moo as dependency
