### PR TITLE
force close cursors after selectall_arrayref

### DIFF
--- a/lib/ZDBA/DBIx.pm
+++ b/lib/ZDBA/DBIx.pm
@@ -77,7 +77,7 @@ sub _fetch {
   $self->log->debug( sub { qq{fetching data from '%s' using '%s' with options:\n%s}, $self->dsn, $method, $self->dump($args) } );
 
   my $start = [gettimeofday];
-  my $options = { MaxRows => 1000, %{ $args->{options} || {} } };
+  my $options = { MaxRows => 1000, %{ $args->{options} // {} } };
 
   my $result = $self->dbh->$method(
     $args->{query},

--- a/lib/ZDBA/DBIx.pm
+++ b/lib/ZDBA/DBIx.pm
@@ -77,11 +77,11 @@ sub _fetch {
   $self->log->debug( sub { qq{fetching data from '%s' using '%s' with options:\n%s}, $self->dsn, $method, $self->dump($args) } );
 
   my $start = [gettimeofday];
+  my $options = { MaxRows => 1000, %{ $args->{options} || {} } };
 
   my $result = $self->dbh->$method(
     $args->{query},
-    $args->{options},
-    @{ $args->{bind_values} }
+    $options
   );
 
   my $end = [gettimeofday];


### PR DESCRIPTION
closes #77 

for some reason there's this condition in `DBI#selectall_arrayref` which is the root cause of an ORA-01000 error
```perl
$sth->finish if defined $MaxRows;
```

I've added `MaxRows` parameter with default value 1000. I think it's more than enough for monitoring purposes